### PR TITLE
Improve behaviour of verify (-v) mode

### DIFF
--- a/cmd/cfn-format/main.go
+++ b/cmd/cfn-format/main.go
@@ -96,11 +96,14 @@ func main() {
 	output := format.Template(source, options)
 
 	if verifyFlag {
+		if len(fileName) > 0 {
+			fmt.Fprint(os.Stderr, fileName+": ")
+		}
 		if string(input) == output {
-			fmt.Println("Formatted OK")
+			fmt.Fprintln(os.Stderr, "formatted OK")
 			os.Exit(0)
 		} else {
-			die(output)
+			die("would reformat")
 		}
 	}
 


### PR DESCRIPTION
This patch improves the behaviour of verification mode based on feedback
in https://github.com/awslabs/aws-cloudformation-template-formatter/issues/12

Prior to this, using `-v` would either result in `Formatted OK` being
printed to stdout, or a reformatted template being printed to stderr
(depending on whether cfn-format's output is idempotent).

With this change:
- All `-v` output is now directed to stderr
- When a filename is specified, it will be printed as part of the output
  (omitted if a template is read via stdin)
- If cfn-format would reformat the template, the text "would reformat"
  is printed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
