### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:alpine as builder
-RUN mkdir /build
-ADD . /build/
 WORKDIR /build
+ADD . .
 ARG opts
 RUN env CGO_ENABLED=0 ${opts} go build -ldflags="-w -s" -o cfn-format ./cmd/cfn-format/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN mkdir /build
 ADD . /build/
 WORKDIR /build
 ARG opts
-RUN env ${opts} go build -ldflags="-w -s" -o cfn-format ./cmd/cfn-format/*
+RUN env CGO_ENABLED=0 ${opts} go build -ldflags="-w -s" -o cfn-format ./cmd/cfn-format/*
 
 FROM scratch
 COPY --from=builder /build/cfn-format /go/bin/cfn-format

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:alpine as builder
+RUN mkdir /build
+ADD . /build/
+WORKDIR /build
+ARG opts
+RUN env ${opts} go build -ldflags="-w -s" -o cfn-format ./cmd/cfn-format/*
+
+FROM scratch
+COPY --from=builder /build/cfn-format /go/bin/cfn-format
+ENTRYPOINT ["/go/bin/cfn-format"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I created a Dockerfile that results in a tiny Docker image (2.81 MB). It accepts arguments to add build variables for creating multi-arch images:

`docker build --build-arg opts="CGO_ENABLED=0 GOARCH=amd64" -t cfn-format .`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
